### PR TITLE
Bind on all addresses on the host

### DIFF
--- a/config-and-run.sh
+++ b/config-and-run.sh
@@ -7,7 +7,11 @@ if [ ! -z "$SERVER_ID" ] && [ ! -z "$MAX_SERVERS" ]; then
   echo "" >> /opt/zookeeper/conf/zoo.cfg
   echo "#Server List" >> /opt/zookeeper/conf/zoo.cfg
   for i in $( eval echo {1..$MAX_SERVERS});do
-    echo "server.$i=zookeeper-$i:2888:3888" >> /opt/zookeeper/conf/zoo.cfg
+    if [ "$SERVER_ID" = "$i" ];then
+      echo "server.$i=0.0.0.0:2888:3888" >> /opt/zookeeper/conf/zoo.cfg
+    else
+      echo "server.$i=zookeeper-$i:2888:3888" >> /opt/zookeeper/conf/zoo.cfg
+    fi
   done
   cat /opt/zookeeper/conf/zoo.cfg
 


### PR DESCRIPTION
When I try to run this image on kubernetes in clustered mode, I get this error on the first pod:

```
2015-09-01 20:15:44,191 [myid:1] - INFO  [zookeeper-1/10.247.158.49:3888:QuorumCnxManager$Listener@504] - My election bind port: zookeeper-1/10.247.158.49:3888
2015-09-01 20:15:44,191 [myid:1] - ERROR [zookeeper-1/10.247.158.49:3888:QuorumCnxManager$Listener@517] - Exception while listening
java.net.BindException: Cannot assign requested address
    at java.net.PlainSocketImpl.socketBind(Native Method)
    at java.net.AbstractPlainSocketImpl.bind(AbstractPlainSocketImpl.java:376)
    at java.net.ServerSocket.bind(ServerSocket.java:376)
    at java.net.ServerSocket.bind(ServerSocket.java:330)
```

I use the following configuration:

```
{
  "kind": "List",
  "apiVersion": "v1",
  "id": "zookeper",
  "items":[
    {
      "kind": "Service",
      "apiVersion": "v1",
      "metadata": {
        "name": "zookeeper-1",
        "labels": {
          "name": "zookeeper-1"
        }
      },
      "spec": {
        "ports": [
          {
            "name": "client",
            "port": 2181,
            "targetPort": 2181
          },
          {
            "name": "followers",
            "port": 2888,
            "targetPort": 2888
          },
          {
            "name": "election",
            "port": 3888,
            "targetPort": 3888
          }
        ],
        "selector": {
          "name": "zookeeper-1"
        }
      }
    },
    {
      "kind": "Service",
      "apiVersion": "v1",
      "metadata": {
        "name": "zookeeper-2",
        "labels": {
          "name": "zookeeper-2"
        }
      },
      "spec": {
        "ports": [
          {
            "name": "client",
            "port": 2181,
            "targetPort": 2181
          },
          {
            "name": "followers",
            "port": 2888,
            "targetPort": 2888
          },
          {
            "name": "election",
            "port": 3888,
            "targetPort": 3888
          }
        ],
        "selector": {
          "name": "zookeeper-2"
        }
      }
    },
    {
      "kind": "Service",
      "apiVersion": "v1",
      "metadata": {
        "name": "zookeeper-3",
        "labels": {
          "name": "zookeeper-3"
        }
      },
      "spec": {
        "ports": [
          {
            "name": "client",
            "port": 2181,
            "targetPort": 2181
          },
          {
            "name": "followers",
            "port": 2888,
            "targetPort": 2888
          },
          {
            "name": "election",
            "port": 3888,
            "targetPort": 3888
          }
        ],
        "selector": {
          "name": "zookeeper-3"
        }
      }
    },
    {
      "kind": "ReplicationController",
      "apiVersion": "v1",
      "metadata": {
        "name": "zookeeper-1",
        "labels": {
          "name": "zookeeper-1"
        }
      },
      "spec": {
        "replicas": 1,
        "selector": {
          "name": "zookeeper-1"
        },
        "template": {
          "metadata": {
            "labels": {
              "name": "zookeeper-1"
            }
          },
          "spec": {
            "containers": [
              {
                "name": "zookeeper",
                "image": "fabric8/zookeeper",
                "env":[
                  { "name": "SERVER_ID", "value": "1" },
                  { "name": "MAX_SERVERS", "value": "3" }
                ],
                "ports":[
                  {
                    "containerPort": 2181
                  },
                  {
                    "containerPort": 2888
                  },
                  {
                    "containerPort": 3888
                  }
                ]
              }
            ]
          }
        }
      }
    },
    {
      "kind": "ReplicationController",
      "apiVersion": "v1",
      "metadata": {
        "name": "zookeeper-2",
        "labels": {
          "name": "zookeeper-2"
        }
      },
      "spec": {
        "replicas": 1,
        "selector": {
          "name": "zookeeper-2"
        },
        "template": {
          "metadata": {
            "labels": {
              "name": "zookeeper-2"
            }
          },
          "spec": {
            "containers": [
              {
                "name": "zookeeper",
                "image": "fabric8/zookeeper",
                "env":[
                  { "name": "SERVER_ID", "value": "2" },
                  { "name": "MAX_SERVERS", "value": "3" }
                ],
                "ports":[
                  {
                    "containerPort": 2181
                  },
                  {
                    "containerPort": 2888
                  },
                  {
                    "containerPort": 3888
                  }
                ]
              }
            ]
          }
        }
      }
    },
    {
      "kind": "ReplicationController",
      "apiVersion": "v1",
      "metadata": {
        "name": "zookeeper-3",
        "labels": {
          "name": "zookeeper-3"
        }
      },
      "spec": {
        "replicas": 1,
        "selector": {
          "name": "zookeeper-3"
        },
        "template": {
          "metadata": {
            "labels": {
              "name": "zookeeper-3"
            }
          },
          "spec": {
            "containers": [
              {
                "name": "zookeeper",
                "image": "fabric8/zookeeper",
                "env":[
                  { "name": "SERVER_ID", "value": "3" },
                  { "name": "MAX_SERVERS", "value": "3" }
                ],
                "ports":[
                  {
                    "containerPort": 2181
                  },
                  {
                    "containerPort": 2888
                  },
                  {
                    "containerPort": 3888
                  }
                ]
              }
            ]
          }
        }
      }
    }
  ]
}
```

When I look into the first pod, I have the following server list:

```
server.1=zookeeper-1:2888:3888
server.2=zookeeper-2:2888:3888
server.3=zookeeper-3:2888:3888
```

Zookeeper try to bind a server socket on zookeeper-1/10.247.158.49:3888. This IP address does not match with the pod IP address.

I replaced the hostname by the 0.0.0.0 for the current node :

```
server.1=0.0.0.0:2888:3888
server.2=zookeeper-2:2888:3888
server.3=zookeeper-3:2888:3888
```

...

Everything seems to work fine now.
